### PR TITLE
Local ssd annotation

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -327,47 +327,6 @@ func useAnnotation(pool v1alpha1.WorkerPool) (bool, int){
 	return false, 0
 }
 
-func appendDisks(componentName string, pool v1alpha1.WorkerPool) {
-	if strings.Contains(strings.ToLower(componentName), strings.ToLower("tikv")) || strings.Contains(strings.ToLower(componentName), strings.ToLower("tiflash")) {
-		//disks = append(disks, map[string]interface{}{
-		//	"autoDelete": true,
-		//	"boot":       false,
-		//	"sizeGb":     volumeSize,
-		//	"type":       "SCRATCH",
-		//	"interface":  "NVME",
-		//	"image":      machineImage,
-		//	"labels": map[string]interface{}{
-		//		"name": w.worker.Name,
-		//	},
-		//})
-
-		mArry := strings.Split(pool.MachineType, "-")
-		if len(mArry) > 1 {
-			mType, err := strconv.ParseInt(mArry[len(mArry)-1], 10, 64)
-			if err != nil {
-				//ignore
-			} else {
-				if mType >= 8 {
-					for i := 0; i < 5; i++ {
-						disks = append(disks, map[string]interface{}{
-							"autoDelete": true,
-							"boot":       false,
-							"sizeGb":     volumeSize,
-							"type":       "SCRATCH",
-							"interface":  "NVME",
-							"image":      machineImage,
-							"labels": map[string]interface{}{
-								"name": w.worker.Name,
-							},
-						})
-					}
-				}
-			}
-		}
-
-	}
-}
-
 func createDiskSpec(volume v1alpha1.Volume, workerName string, machineImage string, boot bool) (map[string]interface{}, error) {
 	volumeSize, err := worker.DiskSize(volume.Size)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #
Add 2 annotationes for worker to support mount SSD to machines.
- pingcap.com/gcp-provider-annotation // specific whether enable use annotation way to mount SSD volumes
- pingcap.com/gcp-local-volume-count // specific the number of volumes

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
